### PR TITLE
fix(Radio): radio group [optionType: 'button'] display error

### DIFF
--- a/packages/components/src/radio/index.ts
+++ b/packages/components/src/radio/index.ts
@@ -23,10 +23,6 @@ export type RadioGroupProps = typeof ElRadioGroup & {
   optionType: 'defalt' | 'button'
 }
 
-const TransformElRadioGroup = transformComponent(ElRadioGroup, {
-  change: 'input',
-})
-
 const RadioGroupOption = defineComponent({
   name: 'FRadioGroup',
   props: {
@@ -80,7 +76,7 @@ const RadioGroupOption = defineComponent({
             }
           : slots
       return h(
-        TransformElRadioGroup,
+        ElRadioGroup,
         {
           ...attrs,
         },


### PR DESCRIPTION
input.checked status errors in ElRadio, because the input event emit by ElRadioGroup is a native Event. ElRadioGroup no need to transform events