### PR TITLE
fix(FormItem): redundant commas in feedbackText

### DIFF
--- a/packages/components/src/form-item/index.ts
+++ b/packages/components/src/form-item/index.ts
@@ -517,19 +517,12 @@ const Item = connect(
       if (isVoidField(field)) return props
       if (!field) return props
       const takeMessage = () => {
-        const split = (messages: any[]) => {
-          return messages.reduce((buf, text, index) => {
-            if (!text) return buf
-            return index < messages.length - 1
-              ? buf.concat([text, ', '])
-              : buf.concat([text])
-          }, [])
-        }
+        const rejectEmpty = (messages: any[]) => messages.filter(msg => !!msg)
         if (field.validating) return
         if (props.feedbackText) return props.feedbackText
-        if (field.selfErrors.length) return split(field.selfErrors)
-        if (field.selfWarnings.length) return split(field.selfWarnings)
-        if (field.selfSuccesses.length) return split(field.selfSuccesses)
+        if (field.selfErrors.length) return rejectEmpty(field.selfErrors)
+        if (field.selfWarnings.length) return rejectEmpty(field.selfWarnings)
+        if (field.selfSuccesses.length) return rejectEmpty(field.selfSuccesses)
       }
       const errorMessages = takeMessage()
       return {


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `main` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
When there are multiple error messages, feedbackText contains redundant commas.

![image](https://github.com/user-attachments/assets/e8837d4e-2bc5-477b-9e34-197ed9ab3845)